### PR TITLE
Update bem.py

### DIFF
--- a/mne/bem.py
+++ b/mne/bem.py
@@ -1226,7 +1226,7 @@ def _extract_volume_info(mgz, raise_error=True):
     vol_info['filename'] = mgz
     vol_info['volume'] = header['dims'][:3]
     vol_info['voxelsize'] = header['delta']
-    vol_info['xras'], vol_info['yras'], vol_info['zras'] = header['Mdc'].T
+    vol_info['xras'], vol_info['yras'], vol_info['zras'] = header['Mdc']
     vol_info['cras'] = header['Pxyz_c']
     return vol_info
 


### PR DESCRIPTION
Fixed the bug with extracting the RAS coordinate matrix in _extract_volume_info. The correct matrix is stored in header['Mdc'] rather than header['Mdc'].T. Now the saved watershed bem surfaces will have the correct orientations when viewed with Freeview.

Thanks for contributing a pull request! Please make sure you have read the
[contribution guidelines](https://mne.tools/dev/install/contributing.html)
before submitting.

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Again, thanks for contributing!

#### Reference issue
Fixes #7570.


#### What does this implement/fix?
This change fixes the volume information stored with saved BEM surfaces extracted from the watershed algorithm. Previously the correct RAS coordinate matrix was transposed, resulting in flipped orientation when opened with Freeview. Now the RAS matrix is not transposed, and saved BEM surfaces have correct orientations when opened with Freeview. 


#### Additional information
Thanks to @yh-luo and @larsoner for looking into this bug. 
