### PR TITLE
FIX: correct watershed BEM surface orientation

### DIFF
--- a/mne/bem.py
+++ b/mne/bem.py
@@ -1226,7 +1226,7 @@ def _extract_volume_info(mgz, raise_error=True):
     vol_info['filename'] = mgz
     vol_info['volume'] = header['dims'][:3]
     vol_info['voxelsize'] = header['delta']
-    vol_info['xras'], vol_info['yras'], vol_info['zras'] = header['Mdc'].T
+    vol_info['xras'], vol_info['yras'], vol_info['zras'] = header['Mdc']
     vol_info['cras'] = header['Pxyz_c']
     return vol_info
 


### PR DESCRIPTION
Corrected the RAS coordinate matrix used to define the volume info of saved BEM surfaces extracted using Freesurfer watershed algorithm.

Thanks for contributing a pull request! Please make sure you have read the
[contribution guidelines](https://mne.tools/dev/install/contributing.html)
before submitting.

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Again, thanks for contributing!

#### Reference issue
Fixes #7570

#### What does this implement/fix?
This fix corrects the RAS coordinate matrix extracted from T1.mgz by _extract_volume_info(). Previously it was calling the transposed matrix, which flips the Y and Z dimensions when using Freeview to plot the saved BEM surfaces. This fix corrects this behavior. 


#### Additional information
Thanks to @yh-luo and @larsoner. 
